### PR TITLE
Update package.json exports to avoid typescript error

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,10 @@
   "exports": {
     ".": {
       "solid": "./dist/source/index.jsx",
-      "import": "./dist/esm/index.js",
+      "import": {
+        "default": "./dist/esm/index.js",
+        "types": "./dist/types/index.d.ts"
+      },
       "browser": {
         "import": "./dist/esm/index.js",
         "require": "./dist/cjs/index.js"


### PR DESCRIPTION
I have a very simple solid-start application and without this change I get the following type error:
```
Could not find a declaration file for module 'solid-textarea-autosize'. '...node_modules/solid-textarea-autosize/dist/esm/index.js' implicitly has an 'any' type.
  There are types at '.../node_modules/solid-textarea-autosize/dist/types/index.d.ts', but this result could not be resolved when respecting package.json "exports". The 'solid-textarea-autosize' library may need to update its package.json or typings.ts(7016)
```
It might make sense to also do this for the `require` export config also.
